### PR TITLE
fix: handle error and return gracefully during failures

### DIFF
--- a/lib/fluent/plugin/out_gcs.rb
+++ b/lib/fluent/plugin/out_gcs.rb
@@ -102,16 +102,21 @@ module Fluent::Plugin
     end
 
     def start
-      @gcs = Google::Cloud::Storage.new(
-        project: @project,
-        keyfile: @credentials,
-        retries: @client_retries,
-        timeout: @client_timeout
-      )
-      @gcs_bucket = @gcs.bucket(@bucket)
+      begin
+        @gcs = Google::Cloud::Storage.new(
+          project: @project,
+          keyfile: @credentials,
+          retries: @client_retries,
+          timeout: @client_timeout
+        )
+        @gcs_bucket = @gcs.bucket(@bucket)
 
-      ensure_bucket
-      super
+        ensure_bucket
+        super
+      rescue => e
+        log.warn "GCS output plugin initialization error: #{e.message}"
+        log.warn "#{e.full_message()}"
+      end
     end
 
     def format(tag, time, record)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| Related tickets | Related to https://github.com/banzaicloud/logging-operator/issues/491
| License         | Apache 2.0


### What's in this PR?
Adding error handling around `start()` to log and skip errors instead of cascading failures.


### Why?
We were seeing errors like this in our fluentd logs and then the pod would get restarted due to fluentd daemon erroring out:
```
2022-06-02 21:02:07 +0000 [error]: #0 unexpected error error_class=Google::Cloud::PermissionDeniedError error="forbidden: shopify-log-operator-sa@avalara-connectors-dev-dm0qy.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket."
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/google-cloud-storage-1.36.2/lib/google/cloud/storage/service.rb:764:in `rescue in execute'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/google-cloud-storage-1.36.2/lib/google/cloud/storage/service.rb:761:in `execute'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/google-cloud-storage-1.36.2/lib/google/cloud/storage/service.rb:91:in `get_bucket'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/google-cloud-storage-1.36.2/lib/google/cloud/storage/project.rb:225:in `bucket'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/fluent-plugin-gcs-0.4.0/lib/fluent/plugin/out_gcs.rb:111:in `start'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/fluentd-1.14.6/lib/fluent/root_agent.rb:203:in `block in start'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/fluentd-1.14.6/lib/fluent/root_agent.rb:182:in `block (2 levels) in lifecycle'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/fluentd-1.14.6/lib/fluent/agent.rb:121:in `block (2 levels) in lifecycle'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/fluentd-1.14.6/lib/fluent/agent.rb:120:in `each'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/fluentd-1.14.6/lib/fluent/agent.rb:120:in `block in lifecycle'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/fluentd-1.14.6/lib/fluent/agent.rb:113:in `each'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/fluentd-1.14.6/lib/fluent/agent.rb:113:in `lifecycle'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/fluentd-1.14.6/lib/fluent/root_agent.rb:181:in `block in lifecycle'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/fluentd-1.14.6/lib/fluent/root_agent.rb:178:in `each'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/fluentd-1.14.6/lib/fluent/root_agent.rb:178:in `lifecycle'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/fluentd-1.14.6/lib/fluent/root_agent.rb:202:in `start'
  2022-06-02 21:02:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.7.0/gems/fluentd-1.14.6/lib/fluent/engine.rb:248:in `start'
```
This behavior has been observed with the ES plugin too and the related ticket is linked above in the PR description above.

The plugin during start, tries to fetch bucket info and also ensure that the bucket exists.
in this process, if the output configs don't have sufficient permissions or privileges to execute any of the gcp apis, it errors with forbidden and fails.

this is problematic in the logging operator context esp., when we allow different teams to setup their log flows with their output sinks and only one of those sinks have an issue. we would expect the rest of the logging ecosystem to work well, while the specific flow fails gracefully without bombing the entire setup

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
